### PR TITLE
Fix inverted first/last seen

### DIFF
--- a/api/servers.go
+++ b/api/servers.go
@@ -98,8 +98,8 @@ func Servers(db *sql.DB) []ServerAPIResponse {
 			&status.Status,
 			&status.IsListed,
 			&status.UpdatedAt,
-			&status.LastSeen,
 			&status.FirstSeen,
+			&status.LastSeen,
 			&status.Count,
 		)
 


### PR DESCRIPTION
First seen/last seen are backwards.

`GET /api/servers/` 

Notice in the data that `first_seen` is after `last_seen`
<img width="342" alt="Screenshot_20230120_084458" src="https://user-images.githubusercontent.com/1517368/213835570-99569c70-20ab-455e-b1f6-394977d01f48.png">

The SQL query column order:

https://github.com/amoeba/ac-server-monitor/blob/9e99839151bb25be5616907d68b3b33d2860aede/api/servers.go#L67-L68

`Scan` order:
https://github.com/amoeba/ac-server-monitor/blob/9e99839151bb25be5616907d68b3b33d2860aede/api/servers.go#L101-L102
