### PR TITLE
chore(go): bump toolchain to go1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module monitor
 
-go 1.24.5
+go 1.26.0
+
+toolchain go1.26.0
 
 require github.com/mattn/go-sqlite3 v1.14.11
 

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module monitor
 
 go 1.26.0
 
-toolchain go1.26.0
-
 require github.com/mattn/go-sqlite3 v1.14.11
 
 require (


### PR DESCRIPTION
Updates the Go version and adds a toolchain directive in `go.mod` to use Go 1.26.0.