### PR TITLE
chore(go): bump toolchain to go1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module monitor
 
 go 1.26.2
 
-toolchain go1.26.2
-
 require github.com/mattn/go-sqlite3 v1.14.11
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module monitor
 
-go 1.24.5
+go 1.26.2
+
+toolchain go1.26.2
 
 require github.com/mattn/go-sqlite3 v1.14.11
 


### PR DESCRIPTION
Updates the Go version and toolchain directive in `go.mod` to the latest stable release, go1.26.2.