### PR TITLE
chore(go): bump go version to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module monitor
 
-go 1.24.5
+go 1.26.2
 
 require github.com/mattn/go-sqlite3 v1.14.11
 


### PR DESCRIPTION
Updates the Go version directive in `go.mod` from `1.24.5` to `1.26.2`.